### PR TITLE
Update _continuous_distns.py

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8589,8 +8589,8 @@ class powerlaw_gen(rv_continuous):
 
     .. math::
 
-        f(x, a) = a x^{a-1}
-
+        f(x, a) = C x^{a-1}
+        C = a/(x_max**a - x_min**b)
     for :math:`0 \le x \le 1`, :math:`a > 0`.
 
     `powerlaw` takes ``a`` as a shape parameter for :math:`a`.
@@ -8598,7 +8598,7 @@ class powerlaw_gen(rv_continuous):
     %(after_notes)s
 
     For example, the support of `powerlaw` can be adjusted from the default
-    interval ``[0, 1]`` to the interval ``[c, c+d]`` by setting ``loc=c`` and
+    interval ``[x_min, x_max]`` to the interval ``[c, c+d]`` by setting ``loc=c`` and
     ``scale=d``. For a power-law distribution with infinite support, see
     `pareto`.
 
@@ -8608,23 +8608,38 @@ class powerlaw_gen(rv_continuous):
 
     """
     def _shape_info(self):
-        return [_ShapeInfo("a", False, (0, np.inf), (False, False))]
+            return [
+                _ShapeInfo("a", False, (0, np.inf), (False, False)),
+                _ShapeInfo("xmin", False, (0, np.inf), (True, False)),
+                _ShapeInfo("xmax", False, (0, np.inf), (True, False))
+            ]
 
-    def _pdf(self, x, a):
-        # powerlaw.pdf(x, a) = a * x**(a-1)
-        return a*x**(a-1.0)
+    def _pdf(self, x, a, xmin, xmax):
+            if np.any(xmax <= xmin):
+                raise ValueError("xmax must be greater than xmin")
+            return  a * x**(a-1) / (xmax**a - xmin**a)
 
-    def _logpdf(self, x, a):
-        return np.log(a) + sc.xlogy(a - 1, x)
+    def _logpdf(self, x, a, xmin, xmax):
+        if np.any(xmax <= xmin):
+            raise ValueError("xmax must be greater than xmin")
+        return np.log(a) + (a-1)*np.log(x) - np.log(xmax**a - xmin**a)
 
-    def _cdf(self, x, a):
-        return x**(a*1.0)
 
-    def _logcdf(self, x, a):
-        return a*np.log(x)
+    def _cdf(self, x, a, xmin, xmax):
+        if np.any(xmax <= xmin):
+            raise ValueError("xmax must be greater than xmin")
+        return (x**a - xmin**a) / (xmax**a - xmin**a)
 
-    def _ppf(self, q, a):
-        return pow(q, 1.0/a)
+
+    def _logcdf(self, x, a, xmin, xmax):
+        if np.any(xmax <= xmin):
+            raise ValueError("xmax must be greater than xmin")
+        return np.log(x**a - xmin**a) - np.log(xmax**a - xmin**a)
+
+    def _ppf(self, q, a, xmin, xmax):
+        if np.any(xmax <= xmin):
+            raise ValueError("xmax must be greater than xmin")
+        return (q*(xmax**a - xmin**a) + xmin**a)**(1/a)
 
     def _sf(self, p, a):
         return -sc.powm1(p, a)


### PR DESCRIPTION
Updated the power_law class to allow generation of PDFs, CDFs, and random samples over arbitrary domains while preserving the correct distribution shape.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-#23648

#### What does this implement/fix?
This update allows the use of scipy.stats for power-law distributions over arbitrary domains without relying on loc and scale, which alter the functional behavior of the PDF.

With this implementation, one can define a power-law distribution and generate samples over any domain $[x_{\mathrm{min}}, x_{\mathrm{max}}]$ while preserving the correct PDF shape. Previously, samples had to be drawn over $[0,1]$; otherwise, the resulting samples would not follow the intended distribution.

Testing

We validated the implementation using a manually implemented inverse transform sampling method for a power-law distribution over an arbitrary domain. The samples generated with this method were compared to those from the updated SciPy implementation, showing excellent overlap and confirming that the distribution is correctly preserved.

<img width="623" height="467" alt="image" src="https://github.com/user-attachments/assets/dcffca0f-9dbd-4074-8c1c-f7130534bb9f" />

Below is the code used to generate the plot above, demonstrating sampling and PDF evaluation using the modified SciPy powerlaw implementation.

```
import numpy as np
import matplotlib.pyplot as plt
from scipy.stats import powerlaw

# ---------------- Parameters ----------------
x_min, x_max = 1, 3          # Domain of the distribution
exponent = 3                 # Power-law exponent
size = 1_000_000             # Number of samples
bins = 50                    # Histogram bins

# ---------------- SciPy  ----------------
samples = powerlaw.rvs(a=exponent, xmin=x_min, xmax=x_max, size=size)

# ---------------- Manual Inverse Transform Sampling ----------------
manual_samples = sample(x_min, x_max, exponent, size)

# ---------------- Plot ----------------
x_vals = np.linspace(x_min, x_max, 1000)

plt.hist(samples, bins=bins, density=True, alpha=0.6, histtype='step', label='SciPy modified')
plt.hist(manual_samples, bins=bins, density=True, alpha=0.5, histtype='step', label='Inverse Transform Sampling')
plt.plot(x_vals, powerlaw.pdf(x_vals, a=exponent, xmin=x_min, xmax=x_max), 'r-', lw=2, label='PDF SciPy modified')

plt.xlabel('x')
plt.ylabel('Density')
plt.legend()
plt.tight_layout()
plt.show()

```
#### Additional information
Even though great progress has been made, there are still a few issues. For instance, it would be useful to have xmin and xmax defined with default values of 0.0 and 1.0. However, I am encountering the following error: TypeError: defaults are not allowed for shapes. Perhaps the developers could provide guidance on this issue.
